### PR TITLE
action: filter out any deleted items in the PR

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,10 @@ const getPullRequestChangedFiles = async (octokit) => {
     pull_number: getPullRequestNumber(),
   });
 
-  let filesChanged = data.map((v) => v.filename);
+  // We cannot lint any files which have been deleted in this PR.
+  let filesChanged =
+      data.filter(item => item.status !== "deleted")
+          .map((v) => v.filename);
   const fileTypeJsonString = core.getInput('exclude-types');
   const pathJsonString = core.getInput('excludes');
 


### PR DESCRIPTION
Because swift-format acts upon the source files as present in the index,
we cannot lint the files which were removed (not that the results from
that are particularly useful).  Filter out any removed items.  This
incidentally improves the semantics of the function.